### PR TITLE
docs(README): add information and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ like requests for a driver that has not yet been written.
 If you found an issue or want to contribute code, please read
 the [contributing guidelines](CONTRIBUTING.md).
 
-If would like to have a repository considered for inclusion in the 
-Motorcycle.js Github and NPM organizations please, open an issue first to avoid
+If would like to have a repository considered for inclusion in the
+Motorcycle.js Github and NPM organizations, please open an issue first to avoid
 duplication of effort and further the possibility of your work being accepted.
 Afterwards, please refer to our [repository guidelines](REPOSITORIES.md).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you found an issue or want to contribute code, please read
 the [contributing guidelines](CONTRIBUTING.md).
 
 If would like to have a repository considered for inclusion in the 
-Motorcycle.js Github and NPM organizations please open an issue first to avoid
+Motorcycle.js Github and NPM organizations please, open an issue first to avoid
 duplication of effort and further the possibility of your work being accepted.
 Afterwards, please refer to our [repository guidelines](REPOSITORIES.md).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,34 @@
 # Motorcycle
 
-This is the place to discuss features or issues unrelated or general to any library, 
+This is the place to discuss features or issues unrelated or general to any library,
 like requests for a driver that has not yet been written.
+
+## Want to Contribute?
+
+If you found an issue or want to contribute code, please read
+the [contributing guidelines](CONTRIBUTING.md).
+
+If would like to have a repository considered for inclusion in the 
+Motorcycle.js Github and NPM organizations please open an issue first to avoid
+duplication of effort and further the possibility of your work being accepted.
+Afterwards, please refer to our [repository guidelines](REPOSITORIES.md).
+
+## Motorcycle.js Links
+
+- [Motorcycle.js Core](https://github.com/motorcyclejs/core) - Core of Motorcycle.js
+
+#### Drivers
+- [@motorcycle/dom](https://github.com/motorcyclejs/dom) - Standard DOM Driver
+built on Snabbdom
+- [@motorcycle/history](https://github.com/motorcyclejs/history) - Standard
+Hisotry API Driver built on rackt/history
+- [@motorcycle/html](https://github.com/motorcyclejs/html) - Standard HTML
+driver built on snabbdom-to-html
+- [@motorcycle/http](https://github.com/motorcyclejs/http) - Standard HTTP
+driver build on superagent
+- [@motorcycle/local-storage](https://github.com/motorcyclejs/local-storage) -
+Standard local storage driver
+
+#### Utilities
+- [most-subject](https://github.com/TylorS/most-subject) - A subject
+implementation for Most.js


### PR DESCRIPTION
Adds a section about contributing to the project which
touches on the process to having a repository transferred to
the motorcyclejs Github and NPM organizations.
Add a section dedicated to Motorcycle.js and related links
with drivers and utilities subsections.

closes #9
